### PR TITLE
docs: Fix issue of `Coming Soon` logos not responsive for smaller screen sizes

### DIFF
--- a/docs/website/.vitepress/config.mts
+++ b/docs/website/.vitepress/config.mts
@@ -26,7 +26,7 @@ export default defineConfig({
   head: [
     [
         "link", 
-        { rel: "icon", href: "/mobile-ui-sdks/asgardeo-dark.svg" }
+        { rel: "icon", href: "/mobile-ui-sdks/asgardeo-light.svg" }
     ]
   ],
   themeConfig: {

--- a/docs/website/index.md
+++ b/docs/website/index.md
@@ -36,12 +36,12 @@ features:
   - icon:
       light: /ios-light.svg
       dark: /ios-dark.svg
-      width: 50%
+      width: 161.67
     title: iOS SDK
     details: iOS SDK for Asgardeo.
   - icon:
       src: /flutter.svg
-      width: 50%
+      width: 161.67
     title: Flutter SDK
     details: Flutter SDK for Asgardeo.
 ---


### PR DESCRIPTION
## Purpose
$subject.

## Related Issues
- https://github.com/asgardeo/mobile-ui-sdks/issues/34

## Screenshots

After fixing the issue
<img width="798" alt="Screenshot 2024-08-12 at 11 41 51" src="https://github.com/user-attachments/assets/8e16c502-554f-4af5-8ee0-d1b9e9f307d7">
